### PR TITLE
docs/organize TOC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,14 @@
 ```{toctree}
 :maxdepth: 1
 :hidden:
-
+:caption: Vignettes
 example.ipynb
+```
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+:caption: Developer Notes
 changelog.md
 contributing.md
 conduct.md


### PR DESCRIPTION
A small edit to reorganize the readthedocs table of contents to include the tutorial under 'Vignettes' and the other documents under 'Developer Notes'